### PR TITLE
feat: adopt Lit recommended decorators tsconfig settings and TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "@greenwood/cli": "^0.34.0",
     "@greenwood/plugin-adapter-vercel": "^0.34.0",
     "@greenwood/plugin-renderer-lit": "^0.34.0",
-    "typescript": "^5.8.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "NODE_OPTIONS='--import @greenwood/cli/register' greenwood build",
     "serve": "greenwood serve",
     "start": "pnpm run build && pnpm run serve",
-    "check:types": "tsc"
+    "lint:types": "tsc"
   },
   "dependencies": {
     "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "NODE_OPTIONS='--import @greenwood/cli/register' greenwood build",
     "serve": "greenwood serve",
     "start": "pnpm run build && pnpm run serve",
-    "lint:types": "tsc"
+    "check:types": "tsc"
   },
   "dependencies": {
     "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "NODE_OPTIONS='--import @greenwood/cli/register' greenwood build",
     "serve": "greenwood serve",
     "start": "pnpm run build && pnpm run serve",
-    "lint:types": "tsc"
+    "check": "tsc"
   },
   "dependencies": {
     "lit": "^3.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^0.34.0
         version: 0.34.0(@greenwood/cli@0.34.0)(lit@3.3.3)
       typescript:
-        specifier: ^5.8.2
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -909,8 +909,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1866,7 +1866,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@8.3.0: {}
 

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -6,13 +6,13 @@ import sheet from './card.css' with { type: 'css' };
 export class Card extends LitElement {
 
   @property()
-  accessor title: string;
+  accessor title: string = '';
 
   @property()
-  accessor thumbnail: string;
+  accessor thumbnail: string = '';
 
   @property()
-  accessor id: string;
+  accessor id: string = '';
 
   static styles = [sheet];
 

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -7,32 +7,33 @@ import sheet from './modal.css' with { type: 'css' };
 export class Modal extends LitElement {
 
   @state()
-  accessor content: string;
+  accessor content: string = '';
 
   static styles = [sheet];
 
   updateModal(content: string) {
     console.log(`selected item is => ${content}`);
-    const dialog = this.shadowRoot.querySelector('dialog');
+    const dialog = this?.shadowRoot?.querySelector('dialog');
 
     this.content = content;
 
-    dialog.showModal();
+    dialog?.showModal();
   }
 
   connectedCallback() {
     super.connectedCallback();
 
-    window.addEventListener('update-modal', (event: CustomEvent) => {
-      this.updateModal(event.detail.content);
-    })
+    window.addEventListener('update-modal', (event) => {
+      const customEvent = event as CustomEvent<{ content: string }>;
+      this.updateModal(customEvent.detail.content);
+    });
   }
 
   firstUpdated() {
-    const button = this.shadowRoot.querySelector('button');
-    const dialog = this.shadowRoot.querySelector('dialog');
+    const button = this?.shadowRoot?.querySelector('button');
+    const dialog = this?.shadowRoot?.querySelector('dialog');
 
-    button.addEventListener("click", () => dialog.close());
+    button?.addEventListener("click", () => dialog?.close());
   }
 
   render() {

--- a/src/pages/api/fragment.ts
+++ b/src/pages/api/fragment.ts
@@ -10,8 +10,8 @@ export const isolation = true;
 
 export async function handler(request: Request) {
   const params = new URLSearchParams(request.url.slice(request.url.indexOf('?')));
-  const limit = params.has('limit') ? parseInt(params.get('limit'), 10) : 5;
-  const offset = params.has('offset') ? parseInt(params.get('offset'), 10) : 0;
+  const limit = params.has('limit') ? parseInt(params.get('limit') ?? '5', 10) : 5;
+  const offset = params.has('offset') ? parseInt(params.get('offset') ?? '0', 10) : 0;
   const products = (await getProducts()).slice(offset, offset + limit);
   const body = await collectResult(render(html`
     ${

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,11 @@
     "checkJs": true,
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
+
+    // lit specific configurations
+    // https://lit.dev/docs/components/decorators/#decorators-typescript
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
   },
   "exclude": ["./public/", "./greenwood/", "node_modules"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
 
-    // lit specific configurations
+    // Lit recommended settings for decorators
     // https://lit.dev/docs/components/decorators/#decorators-typescript
     "experimentalDecorators": true,
     "useDefineForClassFields": false,

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "pnpm run lint:types && pnpm run build"
+  "buildCommand": "pnpm run check && pnpm run build"
 }


### PR DESCRIPTION
https://lit.dev/docs/components/decorators/#decorators-typescript
```json5
// tsconfig.json
{
  "compilerOptions": {
    "experimentalDecorators": true,
    "useDefineForClassFields": false,
  }
}
```

----

Should we upgrade to TS 6?